### PR TITLE
Avoid using stream api in Result#mergeErrors

### DIFF
--- a/MCStructs-converter/src/main/java/net/lenni0451/mcstructs/converter/model/Result.java
+++ b/MCStructs-converter/src/main/java/net/lenni0451/mcstructs/converter/model/Result.java
@@ -3,10 +3,8 @@ package net.lenni0451.mcstructs.converter.model;
 import lombok.EqualsAndHashCode;
 import lombok.SneakyThrows;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public interface Result<T> {
 


### PR DESCRIPTION
Stream api is not really fast and memory-efficiend, so we'll replace it with faster for-each iterations

This can help to smooth out situations where we're getting **a lot** of errors.